### PR TITLE
Fixed: exists is not defined at line 105

### DIFF
--- a/machines/submit.js
+++ b/machines/submit.js
@@ -102,7 +102,7 @@ module.exports = {
       });
     });
     req.on('error', function (err) {
-      return exists.error(err);
+      return exits.error(err);
     })
     req.write(data);
     req.end();


### PR DESCRIPTION
The API throws a reference error (exists not defined) when the API is called but the host machine doesn't have an internet connection.